### PR TITLE
cosmic-de/cosmic-settings-daemon: Add missing media-sound/alsa-utils dependency

### DIFF
--- a/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-1.0.0_alpha1.ebuild
+++ b/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-1.0.0_alpha1.ebuild
@@ -7,15 +7,14 @@ COSMIC_GIT_UNPACK=1
 inherit cosmic-de
 
 DESCRIPTION="settings daemon for the COSMIC DE"
-HOMEPAGE="https://github.com/pop-os/$PN"
-
-EGIT_REPO_URI="${HOMEPAGE}"
-EGIT_COMMIT="epoch-1.0.0-alpha.1"
-
+HOMEPAGE="https://github.com/pop-os/cosmic-settings-daemon"
 # use cargo-license for a more accurate license picture
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64"
+
+EGIT_REPO_URI="${HOMEPAGE}"
+EGIT_COMMIT="epoch-1.0.0-alpha.1"
 
 RDEPEND="
 	${RDEPEND}

--- a/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-1.0.0_alpha1.ebuild
+++ b/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-1.0.0_alpha1.ebuild
@@ -20,6 +20,7 @@ KEYWORDS="~amd64"
 RDEPEND="
 	${RDEPEND}
 	>=app-misc/geoclue-2.7.1
+	media-sound/alsa-utils
 	>=media-sound/playerctl-2.3.1
 	>=sys-power/acpid-2.0.34-r1
 "

--- a/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-1.0.0_alpha2.ebuild
+++ b/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-1.0.0_alpha2.ebuild
@@ -7,16 +7,16 @@ COSMIC_GIT_UNPACK=1
 inherit cosmic-de
 
 DESCRIPTION="settings daemon for the COSMIC DE"
-HOMEPAGE="https://github.com/pop-os/$PN"
-IUSE="${IUSE} mpris"
-
-EGIT_REPO_URI="${HOMEPAGE}"
-EGIT_COMMIT="epoch-1.0.0-alpha.2"
-
+HOMEPAGE="https://github.com/pop-os/cosmic-settings-daemon"
 # use cargo-license for a more accurate license picture
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64"
+
+EGIT_REPO_URI="${HOMEPAGE}"
+EGIT_COMMIT="epoch-1.0.0-alpha.2"
+
+IUSE="${IUSE} mpris"
 
 RDEPEND="
 	${RDEPEND}

--- a/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-1.0.0_alpha2.ebuild
+++ b/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-1.0.0_alpha2.ebuild
@@ -21,6 +21,7 @@ KEYWORDS="~amd64"
 RDEPEND="
 	${RDEPEND}
 	>=app-misc/geoclue-2.7.1
+	media-sound/alsa-utils
 	mpris? ( >=media-sound/playerctl-2.3.1 )
 	>=sys-power/acpid-2.0.34-r1
 "

--- a/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-1.0.0_alpha3.ebuild
+++ b/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-1.0.0_alpha3.ebuild
@@ -7,16 +7,16 @@ COSMIC_GIT_UNPACK=1
 inherit cosmic-de
 
 DESCRIPTION="settings daemon for the COSMIC DE"
-HOMEPAGE="https://github.com/pop-os/$PN"
-IUSE="${IUSE} mpris"
-
-EGIT_REPO_URI="${HOMEPAGE}"
-EGIT_COMMIT="epoch-1.0.0-alpha.3"
-
+HOMEPAGE="https://github.com/pop-os/cosmic-settings-daemon"
 # use cargo-license for a more accurate license picture
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64"
+
+EGIT_REPO_URI="${HOMEPAGE}"
+EGIT_COMMIT="epoch-1.0.0-alpha.3"
+
+IUSE="${IUSE} mpris"
 
 RDEPEND="
 	${RDEPEND}

--- a/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-1.0.0_alpha3.ebuild
+++ b/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-1.0.0_alpha3.ebuild
@@ -21,6 +21,7 @@ KEYWORDS="~amd64"
 RDEPEND="
 	${RDEPEND}
 	>=app-misc/geoclue-2.7.1
+	media-sound/alsa-utils
 	mpris? ( >=media-sound/playerctl-2.3.1 )
 	>=sys-power/acpid-2.0.34-r1
 "

--- a/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-9999.ebuild
+++ b/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-9999.ebuild
@@ -6,20 +6,16 @@ EAPI=8
 inherit cosmic-de
 
 DESCRIPTION="settings daemon for the COSMIC DE"
-HOMEPAGE="https://github.com/pop-os/$PN"
-IUSE="${IUSE} mpris"
+HOMEPAGE="https://github.com/pop-os/cosmic-settings-daemon"
+# use cargo-license for a more accurate license picture
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS=""
 
 EGIT_REPO_URI="${HOMEPAGE}"
 EGIT_BRANCH=master
 
-# use cargo-license for a more accurate license picture
-LICENSE="GPL-3"
-SLOT="0"
-KEYWORDS="~amd64"
-
-if [[ ${PV} == 9999 ]]; then
-	KEYWORDS=""
-fi
+IUSE="${IUSE} mpris"
 
 RDEPEND="
 	${RDEPEND}

--- a/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-9999.ebuild
+++ b/cosmic-de/cosmic-settings-daemon/cosmic-settings-daemon-9999.ebuild
@@ -24,6 +24,7 @@ fi
 RDEPEND="
 	${RDEPEND}
 	>=app-misc/geoclue-2.7.1
+	media-sound/alsa-utils
 	mpris? ( >=media-sound/playerctl-2.3.1 )
 	>=sys-power/acpid-2.0.34-r1
 "

--- a/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-1.0.0_alpha1
+++ b/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-1.0.0_alpha1
@@ -9,8 +9,8 @@ IUSE=debug debug debug-line-tables-only elogind max-opt systemd
 KEYWORDS=~amd64
 LICENSE=GPL-3
 PROPERTIES=live
-RDEPEND=>=app-misc/geoclue-2.7.1 >=media-sound/playerctl-2.3.1 >=sys-power/acpid-2.0.34-r1 elogind? ( >=sys-auth/elogind-246.10-r3 ) systemd? ( >=sys-apps/systemd-255.3-r1 ) || ( >=sys-apps/dbus-1.15.8 >=sys-apps/dbus-broker-36 )
+RDEPEND=>=app-misc/geoclue-2.7.1 media-sound/alsa-utils >=media-sound/playerctl-2.3.1 >=sys-power/acpid-2.0.34-r1 elogind? ( >=sys-auth/elogind-246.10-r3 ) systemd? ( >=sys-apps/systemd-255.3-r1 ) || ( >=sys-apps/dbus-1.15.8 >=sys-apps/dbus-broker-36 )
 REQUIRED_USE=debug? ( !max-opt ) debug-line-tables-only? ( !debug ) max-opt? ( !debug ) ^^ ( elogind systemd )
 SLOT=0
-_eclasses_=cargo	aed68000b8e49b4c4dd13a256149971f	cosmic-de	4201008cba6a0960d22f8cc0be7df134	flag-o-matic	f14aba975c94ccaa9f357a27e3b17ffe	git-r3	875eb471682d3e1f18da124be97dcc81	multilib	b2a329026f2e404e9e371097dda47f96	multiprocessing	1e32df7deee68372153dca65f4a7c21f	rust-toolchain	3f822985d9297438ed2443aa1fbdf33e	toolchain-funcs	d3d42b22a610ce81c267b644bcec9b87
-_md5_=4a329c3ad1ad371732f17ededd129042
+_eclasses_=toolchain-funcs	d3d42b22a610ce81c267b644bcec9b87	multilib	b2a329026f2e404e9e371097dda47f96	flag-o-matic	f14aba975c94ccaa9f357a27e3b17ffe	multiprocessing	1e32df7deee68372153dca65f4a7c21f	rust-toolchain	3f822985d9297438ed2443aa1fbdf33e	cargo	aed68000b8e49b4c4dd13a256149971f	git-r3	875eb471682d3e1f18da124be97dcc81	cosmic-de	4201008cba6a0960d22f8cc0be7df134
+_md5_=47676fe06207bc66c542624e36d9744e

--- a/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-1.0.0_alpha1
+++ b/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-1.0.0_alpha1
@@ -13,4 +13,4 @@ RDEPEND=>=app-misc/geoclue-2.7.1 media-sound/alsa-utils >=media-sound/playerctl-
 REQUIRED_USE=debug? ( !max-opt ) debug-line-tables-only? ( !debug ) max-opt? ( !debug ) ^^ ( elogind systemd )
 SLOT=0
 _eclasses_=toolchain-funcs	d3d42b22a610ce81c267b644bcec9b87	multilib	b2a329026f2e404e9e371097dda47f96	flag-o-matic	f14aba975c94ccaa9f357a27e3b17ffe	multiprocessing	1e32df7deee68372153dca65f4a7c21f	rust-toolchain	3f822985d9297438ed2443aa1fbdf33e	cargo	aed68000b8e49b4c4dd13a256149971f	git-r3	875eb471682d3e1f18da124be97dcc81	cosmic-de	4201008cba6a0960d22f8cc0be7df134
-_md5_=47676fe06207bc66c542624e36d9744e
+_md5_=44b6a9fd092ef46f2fb46bc1f237b849

--- a/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-1.0.0_alpha2
+++ b/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-1.0.0_alpha2
@@ -13,4 +13,4 @@ RDEPEND=>=app-misc/geoclue-2.7.1 media-sound/alsa-utils mpris? ( >=media-sound/p
 REQUIRED_USE=debug? ( !max-opt ) debug-line-tables-only? ( !debug ) max-opt? ( !debug ) ^^ ( elogind systemd )
 SLOT=0
 _eclasses_=toolchain-funcs	d3d42b22a610ce81c267b644bcec9b87	multilib	b2a329026f2e404e9e371097dda47f96	flag-o-matic	f14aba975c94ccaa9f357a27e3b17ffe	multiprocessing	1e32df7deee68372153dca65f4a7c21f	rust-toolchain	3f822985d9297438ed2443aa1fbdf33e	cargo	aed68000b8e49b4c4dd13a256149971f	git-r3	875eb471682d3e1f18da124be97dcc81	cosmic-de	4201008cba6a0960d22f8cc0be7df134
-_md5_=0257fc8a5809c633b16d9ad6c1165bad
+_md5_=b6417a2e07d1fa7d4b3331148901a0d5

--- a/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-1.0.0_alpha2
+++ b/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-1.0.0_alpha2
@@ -9,8 +9,8 @@ IUSE=mpris debug debug debug-line-tables-only elogind max-opt systemd
 KEYWORDS=~amd64
 LICENSE=GPL-3
 PROPERTIES=live
-RDEPEND=>=app-misc/geoclue-2.7.1 mpris? ( >=media-sound/playerctl-2.3.1 ) >=sys-power/acpid-2.0.34-r1 elogind? ( >=sys-auth/elogind-246.10-r3 ) systemd? ( >=sys-apps/systemd-255.3-r1 ) || ( >=sys-apps/dbus-1.15.8 >=sys-apps/dbus-broker-36 )
+RDEPEND=>=app-misc/geoclue-2.7.1 media-sound/alsa-utils mpris? ( >=media-sound/playerctl-2.3.1 ) >=sys-power/acpid-2.0.34-r1 elogind? ( >=sys-auth/elogind-246.10-r3 ) systemd? ( >=sys-apps/systemd-255.3-r1 ) || ( >=sys-apps/dbus-1.15.8 >=sys-apps/dbus-broker-36 )
 REQUIRED_USE=debug? ( !max-opt ) debug-line-tables-only? ( !debug ) max-opt? ( !debug ) ^^ ( elogind systemd )
 SLOT=0
-_eclasses_=cargo	aed68000b8e49b4c4dd13a256149971f	cosmic-de	4201008cba6a0960d22f8cc0be7df134	flag-o-matic	f14aba975c94ccaa9f357a27e3b17ffe	git-r3	875eb471682d3e1f18da124be97dcc81	multilib	b2a329026f2e404e9e371097dda47f96	multiprocessing	1e32df7deee68372153dca65f4a7c21f	rust-toolchain	3f822985d9297438ed2443aa1fbdf33e	toolchain-funcs	d3d42b22a610ce81c267b644bcec9b87
-_md5_=529f88da3af570c00aa5e376c599fd19
+_eclasses_=toolchain-funcs	d3d42b22a610ce81c267b644bcec9b87	multilib	b2a329026f2e404e9e371097dda47f96	flag-o-matic	f14aba975c94ccaa9f357a27e3b17ffe	multiprocessing	1e32df7deee68372153dca65f4a7c21f	rust-toolchain	3f822985d9297438ed2443aa1fbdf33e	cargo	aed68000b8e49b4c4dd13a256149971f	git-r3	875eb471682d3e1f18da124be97dcc81	cosmic-de	4201008cba6a0960d22f8cc0be7df134
+_md5_=0257fc8a5809c633b16d9ad6c1165bad

--- a/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-1.0.0_alpha3
+++ b/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-1.0.0_alpha3
@@ -13,4 +13,4 @@ RDEPEND=>=app-misc/geoclue-2.7.1 media-sound/alsa-utils mpris? ( >=media-sound/p
 REQUIRED_USE=debug? ( !max-opt ) debug-line-tables-only? ( !debug ) max-opt? ( !debug ) ^^ ( elogind systemd )
 SLOT=0
 _eclasses_=toolchain-funcs	d3d42b22a610ce81c267b644bcec9b87	multilib	b2a329026f2e404e9e371097dda47f96	flag-o-matic	f14aba975c94ccaa9f357a27e3b17ffe	multiprocessing	1e32df7deee68372153dca65f4a7c21f	rust-toolchain	3f822985d9297438ed2443aa1fbdf33e	cargo	aed68000b8e49b4c4dd13a256149971f	git-r3	875eb471682d3e1f18da124be97dcc81	cosmic-de	4201008cba6a0960d22f8cc0be7df134
-_md5_=2201c3c56100fec1f99013cd2481061a
+_md5_=0a5669987e012bb65a49c8b2753cfc0f

--- a/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-1.0.0_alpha3
+++ b/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-1.0.0_alpha3
@@ -9,8 +9,8 @@ IUSE=mpris debug debug debug-line-tables-only elogind max-opt systemd
 KEYWORDS=~amd64
 LICENSE=GPL-3
 PROPERTIES=live
-RDEPEND=>=app-misc/geoclue-2.7.1 mpris? ( >=media-sound/playerctl-2.3.1 ) >=sys-power/acpid-2.0.34-r1 elogind? ( >=sys-auth/elogind-246.10-r3 ) systemd? ( >=sys-apps/systemd-255.3-r1 ) || ( >=sys-apps/dbus-1.15.8 >=sys-apps/dbus-broker-36 )
+RDEPEND=>=app-misc/geoclue-2.7.1 media-sound/alsa-utils mpris? ( >=media-sound/playerctl-2.3.1 ) >=sys-power/acpid-2.0.34-r1 elogind? ( >=sys-auth/elogind-246.10-r3 ) systemd? ( >=sys-apps/systemd-255.3-r1 ) || ( >=sys-apps/dbus-1.15.8 >=sys-apps/dbus-broker-36 )
 REQUIRED_USE=debug? ( !max-opt ) debug-line-tables-only? ( !debug ) max-opt? ( !debug ) ^^ ( elogind systemd )
 SLOT=0
-_eclasses_=cargo	aed68000b8e49b4c4dd13a256149971f	cosmic-de	4201008cba6a0960d22f8cc0be7df134	flag-o-matic	f14aba975c94ccaa9f357a27e3b17ffe	git-r3	875eb471682d3e1f18da124be97dcc81	multilib	b2a329026f2e404e9e371097dda47f96	multiprocessing	1e32df7deee68372153dca65f4a7c21f	rust-toolchain	3f822985d9297438ed2443aa1fbdf33e	toolchain-funcs	d3d42b22a610ce81c267b644bcec9b87
-_md5_=45e5bce62c32263d128fb7a1e9994c9c
+_eclasses_=toolchain-funcs	d3d42b22a610ce81c267b644bcec9b87	multilib	b2a329026f2e404e9e371097dda47f96	flag-o-matic	f14aba975c94ccaa9f357a27e3b17ffe	multiprocessing	1e32df7deee68372153dca65f4a7c21f	rust-toolchain	3f822985d9297438ed2443aa1fbdf33e	cargo	aed68000b8e49b4c4dd13a256149971f	git-r3	875eb471682d3e1f18da124be97dcc81	cosmic-de	4201008cba6a0960d22f8cc0be7df134
+_md5_=2201c3c56100fec1f99013cd2481061a

--- a/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-9999
+++ b/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-9999
@@ -12,4 +12,4 @@ RDEPEND=>=app-misc/geoclue-2.7.1 media-sound/alsa-utils mpris? ( >=media-sound/p
 REQUIRED_USE=debug? ( !max-opt ) debug-line-tables-only? ( !debug ) max-opt? ( !debug ) ^^ ( elogind systemd )
 SLOT=0
 _eclasses_=toolchain-funcs	d3d42b22a610ce81c267b644bcec9b87	multilib	b2a329026f2e404e9e371097dda47f96	flag-o-matic	f14aba975c94ccaa9f357a27e3b17ffe	multiprocessing	1e32df7deee68372153dca65f4a7c21f	rust-toolchain	3f822985d9297438ed2443aa1fbdf33e	cargo	aed68000b8e49b4c4dd13a256149971f	git-r3	875eb471682d3e1f18da124be97dcc81	cosmic-de	4201008cba6a0960d22f8cc0be7df134
-_md5_=a5d6bfddc64d537293bc6d2f653bd76e
+_md5_=c0dba0b23cc29eaccecda2641b9a1561

--- a/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-9999
+++ b/metadata/md5-cache/cosmic-de/cosmic-settings-daemon-9999
@@ -8,8 +8,8 @@ INHERIT=cosmic-de
 IUSE=mpris debug debug debug-line-tables-only elogind max-opt systemd
 LICENSE=GPL-3
 PROPERTIES=live
-RDEPEND=>=app-misc/geoclue-2.7.1 mpris? ( >=media-sound/playerctl-2.3.1 ) >=sys-power/acpid-2.0.34-r1 elogind? ( >=sys-auth/elogind-246.10-r3 ) systemd? ( >=sys-apps/systemd-255.3-r1 ) || ( >=sys-apps/dbus-1.15.8 >=sys-apps/dbus-broker-36 )
+RDEPEND=>=app-misc/geoclue-2.7.1 media-sound/alsa-utils mpris? ( >=media-sound/playerctl-2.3.1 ) >=sys-power/acpid-2.0.34-r1 elogind? ( >=sys-auth/elogind-246.10-r3 ) systemd? ( >=sys-apps/systemd-255.3-r1 ) || ( >=sys-apps/dbus-1.15.8 >=sys-apps/dbus-broker-36 )
 REQUIRED_USE=debug? ( !max-opt ) debug-line-tables-only? ( !debug ) max-opt? ( !debug ) ^^ ( elogind systemd )
 SLOT=0
-_eclasses_=cargo	aed68000b8e49b4c4dd13a256149971f	cosmic-de	4201008cba6a0960d22f8cc0be7df134	flag-o-matic	f14aba975c94ccaa9f357a27e3b17ffe	git-r3	875eb471682d3e1f18da124be97dcc81	multilib	b2a329026f2e404e9e371097dda47f96	multiprocessing	1e32df7deee68372153dca65f4a7c21f	rust-toolchain	3f822985d9297438ed2443aa1fbdf33e	toolchain-funcs	d3d42b22a610ce81c267b644bcec9b87
-_md5_=3817b1147e47faa64c8ab2364649d5e1
+_eclasses_=toolchain-funcs	d3d42b22a610ce81c267b644bcec9b87	multilib	b2a329026f2e404e9e371097dda47f96	flag-o-matic	f14aba975c94ccaa9f357a27e3b17ffe	multiprocessing	1e32df7deee68372153dca65f4a7c21f	rust-toolchain	3f822985d9297438ed2443aa1fbdf33e	cargo	aed68000b8e49b4c4dd13a256149971f	git-r3	875eb471682d3e1f18da124be97dcc81	cosmic-de	4201008cba6a0960d22f8cc0be7df134
+_md5_=a5d6bfddc64d537293bc6d2f653bd76e


### PR DESCRIPTION
`amixer` is used for muting/unmuting sound and microphone, see https://github.com/pop-os/cosmic-settings-daemon/blob/2f17f33875315a4cf463f82c5dceca4d83a75bfd/data/system_actions.ron#L19-L22
`amixer` is provided by `media-sound/alsa-utils` so adding that as a dependency.
Would you prefer revbump for this?

I also fixed the local/simple QA issues reported by `pkgcheck`, there are still a few left but they are either in (non-existing at the moment) metadata or the eclass so didn't want to touch that.
```
$ pkgcheck scan cosmic-de/cosmic-settings-daemon
cosmic-de/cosmic-settings-daemon
  MissingRemoteId: missing <remote-id type="github">pop-os/cosmic-settings-daemon</remote-id> (inferred from URI 'https://github.com/pop-os/cosmic-settings-daemon')
  NonsolvableDepsInStable: version 1.0.0_alpha1: nonsolvable depset(rdepend) keyword(~amd64) stable profile (default/linux/amd64/23.0/split-usr) (22 total): solutions: [ >=sys-apps/systemd-255.3-r1 ]
  RequiredUseDefaults: version 1.0.0_alpha1: profile: 'default/linux/amd64/23.0' (36 total) failed REQUIRED_USE: exactly-one-of ( elogind systemd )
  UnknownUseFlags: version 1.0.0_alpha1: unknown USE flags: 'debug-line-tables-only', 'max-opt'
  VisibleVcsPkg: version 1.0.0_alpha1: VCS version visible for KEYWORDS="~amd64", profile default/linux/amd64/23.0 (68 total)
  NonsolvableDepsInStable: version 1.0.0_alpha2: nonsolvable depset(rdepend) keyword(~amd64) stable profile (default/linux/amd64/23.0/split-usr) (22 total): solutions: [ >=sys-apps/systemd-255.3-r1 ]
  RequiredUseDefaults: version 1.0.0_alpha2: profile: 'default/linux/amd64/23.0' (36 total) failed REQUIRED_USE: exactly-one-of ( elogind systemd )
  UnknownUseFlags: version 1.0.0_alpha2: unknown USE flags: 'debug-line-tables-only', 'max-opt', 'mpris'
  VisibleVcsPkg: version 1.0.0_alpha2: VCS version visible for KEYWORDS="~amd64", profile default/linux/amd64/23.0 (68 total)
  NonsolvableDepsInStable: version 1.0.0_alpha3: nonsolvable depset(rdepend) keyword(~amd64) stable profile (default/linux/amd64/23.0/split-usr) (22 total): solutions: [ >=sys-apps/systemd-255.3-r1 ]
  RequiredUseDefaults: version 1.0.0_alpha3: profile: 'default/linux/amd64/23.0' (36 total) failed REQUIRED_USE: exactly-one-of ( elogind systemd )
  UnknownUseFlags: version 1.0.0_alpha3: unknown USE flags: 'debug-line-tables-only', 'max-opt', 'mpris'
  VisibleVcsPkg: version 1.0.0_alpha3: VCS version visible for KEYWORDS="~amd64", profile default/linux/amd64/23.0 (68 total)
  UnknownUseFlags: version 9999: unknown USE flags: 'debug-line-tables-only', 'max-opt', 'mpris'
```

P.S. Are you using thick manifests for a specific reason? Otherwise it'd be simpler to switch to thin manifest so the busywork/noise of updating the manifest files is no longer necessary.