### PR TITLE
cosmic-comp-9999: Add libdisplay-info dependency

### DIFF
--- a/cosmic-de/cosmic-comp/cosmic-comp-9999.ebuild
+++ b/cosmic-de/cosmic-comp/cosmic-comp-9999.ebuild
@@ -24,6 +24,7 @@ DEPEND="
 	>=sys-auth/seatd-0.8.0
 	>=x11-libs/libxcb-1.16.1
 	>=x11-libs/pixman-0.43.4
+	media-libs/libdisplay-info:0
 "
 
 src_configure() {


### PR DESCRIPTION
This dependency was added recently, via this commit https://github.com/pop-os/cosmic-comp/commit/23570ea9f4b3b47e676dac651d13fd39248f927c#diff-2a13f1344504379e877324d3a0375adcbcb4cb27d7e575ad8f4618a52d6a00e0R32

It seems like whist a Rust package was replaced (edid-rs) no system package was replaced, so this only adds a dependency.

Btw I don't know if you prefer to revbump the live ebuild for changes like this or not? I didn't revbump for now, given that anyone who already has it installed doesn't need the fix and rebuilding will just use the updated version.