### PR TITLE
cosmic-de/cosmic-meta: add greeter useflag

### DIFF
--- a/cosmic-de/cosmic-meta/cosmic-meta-1.0.0_alpha4-r1.ebuild
+++ b/cosmic-de/cosmic-meta/cosmic-meta-1.0.0_alpha4-r1.ebuild
@@ -13,7 +13,7 @@ LICENSE="CC-BY-SA-4.0 GPL-3 GPL-3+ MPL-2.0"
 
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="store"
+IUSE="+greeter store"
 
 RDEPEND="
 ~cosmic-de/cosmic-applets-${PV}
@@ -22,7 +22,10 @@ RDEPEND="
 ~cosmic-de/cosmic-comp-${PV}
 ~cosmic-de/cosmic-edit-${PV}
 ~cosmic-de/cosmic-files-${PV}
-~cosmic-de/cosmic-greeter-${PV}
+greeter? ( 
+    ~cosmic-de/cosmic-greeter-${PV}
+    ~cosmic-de/cosmic-session-${PV}
+)
 ~cosmic-de/cosmic-icons-${PV}
 ~cosmic-de/cosmic-idle-${PV}
 ~cosmic-de/cosmic-launcher-${PV}
@@ -31,7 +34,6 @@ RDEPEND="
 ~cosmic-de/cosmic-panel-${PV}
 ~cosmic-de/cosmic-randr-${PV}
 ~cosmic-de/cosmic-screenshot-${PV}
-~cosmic-de/cosmic-session-${PV}
 ~cosmic-de/cosmic-settings-${PV}
 ~cosmic-de/cosmic-settings-daemon-${PV}
 store? ( ~cosmic-de/cosmic-store-${PV} )

--- a/cosmic-de/cosmic-meta/cosmic-meta-1.0.0_alpha5-r1.ebuild
+++ b/cosmic-de/cosmic-meta/cosmic-meta-1.0.0_alpha5-r1.ebuild
@@ -13,7 +13,7 @@ LICENSE="CC-BY-SA-4.0 GPL-3 GPL-3+ MPL-2.0"
 
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="store"
+IUSE="+greeter store"
 
 RDEPEND="
 ~cosmic-de/cosmic-applets-${PV}
@@ -22,7 +22,10 @@ RDEPEND="
 ~cosmic-de/cosmic-comp-${PV}
 ~cosmic-de/cosmic-edit-${PV}
 ~cosmic-de/cosmic-files-${PV}
-~cosmic-de/cosmic-greeter-${PV}
+greeter? ( 
+    ~cosmic-de/cosmic-greeter-${PV}
+    ~cosmic-de/cosmic-session-${PV}
+)
 ~cosmic-de/cosmic-icons-${PV}
 ~cosmic-de/cosmic-idle-${PV}
 ~cosmic-de/cosmic-launcher-${PV}
@@ -32,7 +35,6 @@ RDEPEND="
 ~cosmic-de/cosmic-player-${PV}
 ~cosmic-de/cosmic-randr-${PV}
 ~cosmic-de/cosmic-screenshot-${PV}
-~cosmic-de/cosmic-session-${PV}
 ~cosmic-de/cosmic-settings-${PV}
 ~cosmic-de/cosmic-settings-daemon-${PV}
 store? ( ~cosmic-de/cosmic-store-${PV} )

--- a/cosmic-de/cosmic-meta/cosmic-meta-9999.ebuild
+++ b/cosmic-de/cosmic-meta/cosmic-meta-9999.ebuild
@@ -13,7 +13,7 @@ LICENSE="CC-BY-SA-4.0 GPL-3 GPL-3+ MPL-2.0"
 
 SLOT="0"
 KEYWORDS=""
-IUSE="store"
+IUSE="+greeter store"
 
 RDEPEND="
 ~cosmic-de/cosmic-applets-${PV}
@@ -22,7 +22,10 @@ RDEPEND="
 ~cosmic-de/cosmic-comp-${PV}
 ~cosmic-de/cosmic-edit-${PV}
 ~cosmic-de/cosmic-files-${PV}
-~cosmic-de/cosmic-greeter-${PV}
+greeter? ( 
+    ~cosmic-de/cosmic-greeter-${PV}
+    ~cosmic-de/cosmic-session-${PV}
+)
 ~cosmic-de/cosmic-icons-${PV}
 ~cosmic-de/cosmic-idle-${PV}
 ~cosmic-de/cosmic-launcher-${PV}
@@ -32,7 +35,6 @@ RDEPEND="
 ~cosmic-de/cosmic-player-${PV}
 ~cosmic-de/cosmic-randr-${PV}
 ~cosmic-de/cosmic-screenshot-${PV}
-~cosmic-de/cosmic-session-${PV}
 ~cosmic-de/cosmic-settings-${PV}
 ~cosmic-de/cosmic-settings-daemon-${PV}
 store? ( ~cosmic-de/cosmic-store-${PV} )

--- a/cosmic-de/cosmic-meta/metadata.xml
+++ b/cosmic-de/cosmic-meta/metadata.xml
@@ -7,6 +7,7 @@
     <description>Primary maintainer</description>
   </maintainer>
   <use>
+    <flag name="greeter"> Enable cosmic-greeter dependency.</flag>
     <flag name="store">Enable cosmic-store dependency.</flag>
   </use>
   <upstream>


### PR DESCRIPTION
This is a small change that allow user that want to test cosmic don't need to pull another greeter.
I use kde so in my machine I will only test the desktop.