### PR TITLE
cosmic-de/cosmic-wallpapers: Use the `mirror` option for git and LFS clones

### DIFF
--- a/cosmic-de/cosmic-wallpapers/cosmic-wallpapers-1.0.0_alpha6.ebuild
+++ b/cosmic-de/cosmic-wallpapers/cosmic-wallpapers-1.0.0_alpha6.ebuild
@@ -11,6 +11,19 @@ HOMEPAGE="https://github.com/pop-os/cosmic-wallpapers"
 inherit git-r3
 EGIT_REPO_URI="${HOMEPAGE}"
 EGIT_COMMIT="epoch-1.0.0-alpha.6"
+# Due to the way things are setup at the moment, we reuse the same `DISTDIR`
+# repo for multiple versions (e.g.: alpha2 -> alpha3 -> alpha4).
+# 
+# Problem is that every time we emerge a new version, the repo with
+# `CLONE_TYPE=single` does not contain all other refs and is not reset, so the
+# user needs to manually remove it and reclone it.
+# 
+# While `CLONE_TYPE=mirror` increases repo size, for cosmic-wallpaper it takes
+# ~18MB. It's still better for the user to cleanup once/year (or whenever)
+# instead of every time a new version hits the repo. Old/deleted refs are
+# purged in this mode.
+EGIT_CLONE_TYPE=mirror
+EGIT_LFS_CLONE_TYPE=mirror
 
 BDEPEND="
 	media-gfx/imagemagick

--- a/cosmic-de/cosmic-wallpapers/cosmic-wallpapers-9999.ebuild
+++ b/cosmic-de/cosmic-wallpapers/cosmic-wallpapers-9999.ebuild
@@ -11,6 +11,19 @@ HOMEPAGE="https://github.com/pop-os/cosmic-wallpapers"
 inherit git-r3
 EGIT_REPO_URI="${HOMEPAGE}"
 EGIT_BRANCH=master
+# Due to the way things are setup at the moment, we reuse the same `DISTDIR`
+# repo for multiple versions (e.g.: alpha2 -> alpha3 -> alpha4).
+# 
+# Problem is that every time we emerge a new version, the repo with
+# `CLONE_TYPE=single` does not contain all other refs and is not reset, so the
+# user needs to manually remove it and reclone it.
+# 
+# While `CLONE_TYPE=mirror` increases repo size, for cosmic-wallpaper it takes
+# ~18MB. It's still better for the user to cleanup once/year (or whenever)
+# instead of every time a new version hits the repo. Old/deleted refs are
+# purged in this mode.
+EGIT_CLONE_TYPE=mirror
+EGIT_LFS_CLONE_TYPE=mirror
 
 BDEPEND="
 	media-gfx/imagemagick


### PR DESCRIPTION
Due to the way things are setup at the moment, we reuse the same `DISTDIR` repo for multiple versions (e.g.: alpha2 -> alpha3 -> alpha4).

Problem is that every time we emerge a new version, the repo with `CLONE_TYPE=single` does not contain all other refs and is not reset, so the user needs to manually remove it and reclone it.

While `CLONE_TYPE=mirror` increases repo size, for cosmic-wallpaper it takes ~18MB. It's still better for the user to cleanup once/year (or whenever) instead of every time a new version hits the repo. Old/deleted refs are purged in this mode.

Fixes #45