### PR TITLE
cosmic-session: add -r12, update 9999: enable "autostart" feature for non-systemd systems

### DIFF
--- a/cosmic-base/cosmic-session/cosmic-session-1.0.0_alpha7-r12.ebuild
+++ b/cosmic-base/cosmic-session/cosmic-session-1.0.0_alpha7-r12.ebuild
@@ -7,15 +7,22 @@ inherit cosmic-de desktop systemd
 
 DESCRIPTION="sessions manager for the COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-session"
+
+MY_PV="epoch-1.0.0-alpha.7"
+SRC_URI="
+	https://github.com/pop-os/${PN}/archive/refs/tags/${MY_PV}.tar.gz -> ${PN}-${PV}.tar.gz
+	https://github.com/fsvm88/cosmic-overlay/releases/download/${PV}/${P}-crates.tar.zst
+	"
+
 # use cargo-license for a more accurate license picture
 LICENSE="GPL-3"
-
 SLOT="0"
-KEYWORDS=""
+KEYWORDS="~amd64"
 IUSE+=" accessibility +greeter cups"
 
-EGIT_REPO_URI="${HOMEPAGE}"
-EGIT_BRANCH=master
+PATCHES=(
+	"${FILESDIR}/backport-131.patch"
+	)
 
 RDEPEND+="
 	~cosmic-base/cosmic-applets-${PV}
@@ -36,7 +43,7 @@ RDEPEND+="
 	~cosmic-base/cosmic-wallpapers-${PV}
 	~cosmic-base/cosmic-workspaces-epoch-${PV}
 	~cosmic-base/xdg-desktop-portal-cosmic-${PV}
-	~cosmic-base/pop-fonts-${PV}
+	~cosmic-base/pop-fonts-9999
 	>=media-fonts/fira-mono-4.202
 	>=media-fonts/fira-sans-4.202
 	>=sys-power/switcheroo-control-2.6-r2


### PR DESCRIPTION
- add r12, which adds `--features autostart` for `elogind` configure path
- add the change to 9999 too
