### PR TITLE
Add gnome-keyring dependency as secrets provider

### DIFF
--- a/cosmic-base/cosmic-meta/cosmic-meta-1.0.0_alpha7-r1.ebuild
+++ b/cosmic-base/cosmic-meta/cosmic-meta-1.0.0_alpha7-r1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://github.com/pop-os/cosmic-epoch"
 LICENSE="CC-BY-SA-4.0 GPL-3 GPL-3+ MPL-2.0"
 
 SLOT="0"
-KEYWORDS=""
+KEYWORDS="~amd64"
 IUSE="+fonts +gnome-keyring +greeter store"
 
 RDEPEND="
@@ -38,7 +38,7 @@ greeter? ( ~cosmic-base/cosmic-greeter-${PV} )
 store? ( ~cosmic-base/cosmic-store-${PV} )
 ~cosmic-base/cosmic-term-${PV}
 ~cosmic-base/cosmic-workspaces-epoch-${PV}
-~cosmic-base/pop-launcher-${PV}
+~cosmic-base/pop-launcher-9999
 ~cosmic-base/pop-theme-meta-9999
 ~cosmic-base/xdg-desktop-portal-cosmic-${PV}
 fonts? (

--- a/cosmic-base/cosmic-meta/metadata.xml
+++ b/cosmic-base/cosmic-meta/metadata.xml
@@ -8,6 +8,7 @@
   </maintainer>
   <use>
     <flag name="fonts">Pull in media-fonts/open-sans and media-fonts/noto to theme-sync GTK apps to COSMIC defaults.</flag>
+    <flag name="gnome-keyring">Enable support for storing passwords via gnome-keyring.</flag>
     <flag name="greeter">Enable cosmic-greeter dependency.</flag>
     <flag name="store">Enable cosmic-store dependency.</flag>
   </use>


### PR DESCRIPTION
This is required in case the user wants a secrets manager