### PR TITLE
Use cosmic-de-r2 eclass in all live ebuilds

### DIFF
--- a/cosmic-base/cosmic-applets/cosmic-applets-9999.ebuild
+++ b/cosmic-base/cosmic-applets/cosmic-applets-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="applets for COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-applets"

--- a/cosmic-base/cosmic-applibrary/cosmic-applibrary-9999.ebuild
+++ b/cosmic-base/cosmic-applibrary/cosmic-applibrary-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="app library for COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-applibrary"

--- a/cosmic-base/cosmic-bg/cosmic-bg-9999.ebuild
+++ b/cosmic-base/cosmic-bg/cosmic-bg-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="display background service for COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-bg"

--- a/cosmic-base/cosmic-comp/cosmic-comp-9999.ebuild
+++ b/cosmic-base/cosmic-comp/cosmic-comp-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de
+inherit cosmic-de-r2
 
 DESCRIPTION="compositor for COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-comp"

--- a/cosmic-base/cosmic-edit/cosmic-edit-9999.ebuild
+++ b/cosmic-base/cosmic-edit/cosmic-edit-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 EGIT_LFS=1
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="text editor from COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-edit"

--- a/cosmic-base/cosmic-files/cosmic-files-9999.ebuild
+++ b/cosmic-base/cosmic-files/cosmic-files-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="file manager from COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-files"

--- a/cosmic-base/cosmic-greeter/cosmic-greeter-9999.ebuild
+++ b/cosmic-base/cosmic-greeter/cosmic-greeter-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 EGIT_LFS=1
 RUST_NEEDS_LLVM=1
 
-inherit cosmic-de pam systemd tmpfiles
+inherit cosmic-de-r2 pam systemd tmpfiles
 
 DESCRIPTION="libcosmic greeter for greetd from COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-greeter"

--- a/cosmic-base/cosmic-idle/cosmic-idle-9999.ebuild
+++ b/cosmic-base/cosmic-idle/cosmic-idle-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 COSMIC_GIT_UNPACK=1
-inherit cosmic-de
+inherit cosmic-de-r2
 
 DESCRIPTION="screen idle daemon for COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-idle"

--- a/cosmic-base/cosmic-initial-setup/cosmic-initial-setup-9999.ebuild
+++ b/cosmic-base/cosmic-initial-setup/cosmic-initial-setup-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 COSMIC_GIT_UNPACK=1
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="initial setup program for COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-initial-setup"

--- a/cosmic-base/cosmic-launcher/cosmic-launcher-9999.ebuild
+++ b/cosmic-base/cosmic-launcher/cosmic-launcher-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="launcher for COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-launcher"

--- a/cosmic-base/cosmic-notifications/cosmic-notifications-9999.ebuild
+++ b/cosmic-base/cosmic-notifications/cosmic-notifications-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="layer shell notifications daemon for COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-notifications"

--- a/cosmic-base/cosmic-osd/cosmic-osd-9999.ebuild
+++ b/cosmic-base/cosmic-osd/cosmic-osd-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de
+inherit cosmic-de-r2
 
 DESCRIPTION="OSD daemon for COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-osd"

--- a/cosmic-base/cosmic-panel/cosmic-panel-9999.ebuild
+++ b/cosmic-base/cosmic-panel/cosmic-panel-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de
+inherit cosmic-de-r2
 
 DESCRIPTION="panel for COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-panel"

--- a/cosmic-base/cosmic-player/cosmic-player-9999.ebuild
+++ b/cosmic-base/cosmic-player/cosmic-player-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="player for COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-player"

--- a/cosmic-base/cosmic-randr/cosmic-randr-9999.ebuild
+++ b/cosmic-base/cosmic-randr/cosmic-randr-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de
+inherit cosmic-de-r2
 
 DESCRIPTION="CLI utility for displaying and configuring wayland outputs from COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-randr"

--- a/cosmic-base/cosmic-screenshot/cosmic-screenshot-9999.ebuild
+++ b/cosmic-base/cosmic-screenshot/cosmic-screenshot-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="utility for capturing screenshots via XDG Desktop Portal from COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-screenshot"

--- a/cosmic-base/cosmic-session/cosmic-session-9999.ebuild
+++ b/cosmic-base/cosmic-session/cosmic-session-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop systemd
+inherit cosmic-de-r2 desktop systemd
 
 DESCRIPTION="sessions manager for the COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-session"

--- a/cosmic-base/cosmic-settings-daemon/cosmic-settings-daemon-9999.ebuild
+++ b/cosmic-base/cosmic-settings-daemon/cosmic-settings-daemon-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de
+inherit cosmic-de-r2
 
 DESCRIPTION="settings daemon for the COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-settings-daemon"

--- a/cosmic-base/cosmic-settings/cosmic-settings-9999.ebuild
+++ b/cosmic-base/cosmic-settings/cosmic-settings-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 RUST_NEEDS_LLVM=1
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="settings application for the COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-settings"

--- a/cosmic-base/cosmic-store/cosmic-store-9999.ebuild
+++ b/cosmic-base/cosmic-store/cosmic-store-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="app store from COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-store"

--- a/cosmic-base/cosmic-term/cosmic-term-9999.ebuild
+++ b/cosmic-base/cosmic-term/cosmic-term-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="terminal emulator (built using alacritty_terminal) from COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-term"

--- a/cosmic-base/cosmic-workspaces-epoch/cosmic-workspaces-epoch-9999.ebuild
+++ b/cosmic-base/cosmic-workspaces-epoch/cosmic-workspaces-epoch-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="workspaces support for COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-workspaces-epoch"

--- a/cosmic-base/pop-launcher/pop-launcher-9999.ebuild
+++ b/cosmic-base/pop-launcher/pop-launcher-9999.ebuild
@@ -5,7 +5,7 @@
 # for now it's too in flux, 9999 is easier
 EAPI=8
 
-inherit cosmic-de
+inherit cosmic-de-r2
 
 DESCRIPTION="Modular IPC-based desktop launcher service"
 HOMEPAGE="https://github.com/pop-os/launcher"

--- a/cosmic-base/system76-power/system76-power-9999.ebuild
+++ b/cosmic-base/system76-power/system76-power-9999.ebuild
@@ -6,7 +6,7 @@
 
 EAPI=8
 
-inherit cosmic-de systemd
+inherit cosmic-de-r2 systemd
 
 DESCRIPTION="system76-power is a utility for managing graphics and power profiles"
 HOMEPAGE="https://github.com/pop-os/system76-power"

--- a/cosmic-base/xdg-desktop-portal-cosmic/xdg-desktop-portal-cosmic-9999.ebuild
+++ b/cosmic-base/xdg-desktop-portal-cosmic/xdg-desktop-portal-cosmic-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 RUST_NEEDS_LLVM=1
 
-inherit cosmic-de systemd
+inherit cosmic-de-r2 systemd
 
 DESCRIPTION="Cosmic backend for xdg-desktop-portal"
 HOMEPAGE="https://github.com/pop-os/xdg-desktop-portal-cosmic"

--- a/cosmic-utils/accounts/accounts-9999.ebuild
+++ b/cosmic-utils/accounts/accounts-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop systemd
+inherit cosmic-de-r2 desktop systemd
 
 DESCRIPTION="Online account management service for the COSMIC desktop"
 HOMEPAGE="https://github.com/cosmic-utils/accounts"

--- a/cosmic-utils/cosmic-ext-applet-caffeine/cosmic-ext-applet-caffeine-9999.ebuild
+++ b/cosmic-utils/cosmic-ext-applet-caffeine/cosmic-ext-applet-caffeine-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="Caffeine Applet for the COSMIC DE"
 HOMEPAGE="https://github.com/tropicbliss/cosmic-ext-applet-caffeine"

--- a/cosmic-utils/cosmic-ext-applet-external-monitor/cosmic-ext-applet-external-monitor-9999.ebuild
+++ b/cosmic-utils/cosmic-ext-applet-external-monitor/cosmic-ext-applet-external-monitor-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="External Monitor Brightness Applet for the COSMIC DE"
 HOMEPAGE="https://github.com/cosmic-utils/cosmic-ext-applet-external-monitor-brightness"

--- a/cosmic-utils/cosmic-ext-applet-gamemode-status/cosmic-ext-applet-gamemode-status-9999.ebuild
+++ b/cosmic-utils/cosmic-ext-applet-gamemode-status/cosmic-ext-applet-gamemode-status-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="GameMode Status COSMIC DE Applet"
 HOMEPAGE="https://github.com/D-Brox/cosmic-ext-applet-gamemode-status"

--- a/cosmic-utils/cosmic-ext-applet-privacy-indicator/cosmic-ext-applet-privacy-indicator-9999.ebuild
+++ b/cosmic-utils/cosmic-ext-applet-privacy-indicator/cosmic-ext-applet-privacy-indicator-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="COSMIC DE Privacy Indicator"
 HOMEPAGE="https://github.com/D-Brox/cosmic-ext-applet-privacy-indicator"

--- a/cosmic-utils/cosmic-ext-classic-menu/cosmic-ext-classic-menu-9999.ebuild
+++ b/cosmic-utils/cosmic-ext-classic-menu/cosmic-ext-classic-menu-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="Classic style customizable application launcher for COSMIC DE"
 HOMEPAGE="https://github.com/championpeak87/cosmic-ext-classic-menu"

--- a/cosmic-utils/examine/examine-9999.ebuild
+++ b/cosmic-utils/examine/examine-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="A system information viewer for the COSMIC DE"
 HOMEPAGE="https://github.com/cosmic-utils/examine"

--- a/cosmic-utils/minimon/minimon-9999.ebuild
+++ b/cosmic-utils/minimon/minimon-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="Minimon COSMIC DE Applet"
 HOMEPAGE="https://github.com/cosmic-utils/minimon-applet"

--- a/cosmic-utils/tweaks/tweaks-9999.ebuild
+++ b/cosmic-utils/tweaks/tweaks-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cosmic-de desktop
+inherit cosmic-de-r2 desktop
 
 DESCRIPTION="A tweaking tool offering access to advanced settings and features for COSMIC DE"
 HOMEPAGE="https://github.com/cosmic-utils/tweaks"


### PR DESCRIPTION
The recent migration to cosmic-de-r2 eclass was applied to versioned ebuilds, but not to the live ones.