### PR TITLE
feat: support bluetooth global use flag for cosmic-base/cosmic-settings

### DIFF
--- a/cosmic-base/cosmic-settings/cosmic-settings-1.0.10.ebuild
+++ b/cosmic-base/cosmic-settings/cosmic-settings-1.0.10.ebuild
@@ -89,9 +89,13 @@ src_install() {
 
 pkg_postinst() {
 	if use bluetooth; then
-		elog "In order for bluetooth to function, you must start and add"
-		elog "bluetooth to your default runlevel:"
-		elog "  rc-service bluetooth start"
-		elog "  rc-update add bluetooth default"
+		elog "In order for bluetooth to function, you must start and enable"
+		elog "bluetooth:"
+		if use systemd; then
+			elog "  systemctl enable --now bluetooth"
+		else
+			elog "  rc-service bluetooth start"
+			elog "  rc-update add bluetooth default"
+		fi
 	fi
 }

--- a/cosmic-base/cosmic-settings/cosmic-settings-1.0.10.ebuild
+++ b/cosmic-base/cosmic-settings/cosmic-settings-1.0.10.ebuild
@@ -16,9 +16,10 @@ SRC_URI="https://github.com/fsvm88/cosmic-overlay/releases/download/${PV}/${PN}-
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE+=" +networkmanager openvpn"
+IUSE+=" +networkmanager openvpn bluetooth"
 
 RDEPEND+="
+	bluetooth? ( >=net-wireless/bluez-5.86 )
 	~cosmic-base/cosmic-icons-${PV}
 	~cosmic-base/cosmic-randr-${PV}
 	>=app-text/iso-codes-4.16.0
@@ -38,6 +39,34 @@ RDEPEND+="
 	>=x11-misc/xkeyboard-config-2.41
 "
 
+src_configure() {
+	local myfeatures=(
+		"a11y"
+		"cosmic-comp-config"
+		"page-accessibility"
+		"page-about"
+		$(usev bluetooth "page-bluetooth")
+		"page-date"
+		"page-default-apps"
+		"page-display"
+		"page-input"
+		"page-legacy-applications"
+		"page-networking"
+		"page-power"
+		"page-region"
+		"page-sound"
+		"page-users"
+		"page-window-management"
+		"page-workspaces"
+		"xdg-portal"
+		"wayland"
+		"single-instance"
+		"wgpu"
+	)
+
+	cosmic-de-r2_src_configure --no-default-features
+}
+
 src_install() {
 	dobin "$(cosmic-common_target_dir)/$PN"
 
@@ -56,4 +85,13 @@ src_install() {
 
 	insinto /usr/share/polkit-1/actions
 	doins resources/polkit-1/actions/com.system76.CosmicSettings.Users.policy
+}
+
+pkg_postinst() {
+	if use bluetooth; then
+		elog "In order for bluetooth to function, you must start and add"
+		elog "bluetooth to your default runlevel:"
+		elog "  rc-service bluetooth start"
+		elog "  rc-update add bluetooth default"
+	fi
 }

--- a/cosmic-base/cosmic-settings/cosmic-settings-1.0.11.ebuild
+++ b/cosmic-base/cosmic-settings/cosmic-settings-1.0.11.ebuild
@@ -89,9 +89,13 @@ src_install() {
 
 pkg_postinst() {
 	if use bluetooth; then
-		elog "In order for bluetooth to function, you must start and add"
-		elog "bluetooth to your default runlevel:"
-		elog "  rc-service bluetooth start"
-		elog "  rc-update add bluetooth default"
+		elog "In order for bluetooth to function, you must start and enable"
+		elog "bluetooth:"
+		if use systemd; then
+			elog "  systemctl enable --now bluetooth"
+		else
+			elog "  rc-service bluetooth start"
+			elog "  rc-update add bluetooth default"
+		fi
 	fi
 }

--- a/cosmic-base/cosmic-settings/cosmic-settings-1.0.11.ebuild
+++ b/cosmic-base/cosmic-settings/cosmic-settings-1.0.11.ebuild
@@ -16,9 +16,10 @@ SRC_URI="https://github.com/fsvm88/cosmic-overlay/releases/download/${PV}/${PN}-
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE+=" +networkmanager openvpn"
+IUSE+=" +networkmanager openvpn bluetooth"
 
 RDEPEND+="
+	bluetooth? ( >=net-wireless/bluez-5.86 )
 	~cosmic-base/cosmic-icons-${PV}
 	~cosmic-base/cosmic-randr-${PV}
 	>=app-text/iso-codes-4.16.0
@@ -38,6 +39,34 @@ RDEPEND+="
 	>=x11-misc/xkeyboard-config-2.41
 "
 
+src_configure() {
+	local myfeatures=(
+		"a11y"
+		"cosmic-comp-config"
+		"page-accessibility"
+		"page-about"
+		$(usev bluetooth "page-bluetooth")
+		"page-date"
+		"page-default-apps"
+		"page-display"
+		"page-input"
+		"page-legacy-applications"
+		"page-networking"
+		"page-power"
+		"page-region"
+		"page-sound"
+		"page-users"
+		"page-window-management"
+		"page-workspaces"
+		"xdg-portal"
+		"wayland"
+		"single-instance"
+		"wgpu"
+	)
+
+	cosmic-de-r2_src_configure --no-default-features
+}
+
 src_install() {
 	dobin "$(cosmic-common_target_dir)/$PN"
 
@@ -56,4 +85,13 @@ src_install() {
 
 	insinto /usr/share/polkit-1/actions
 	doins resources/polkit-1/actions/com.system76.CosmicSettings.Users.policy
+}
+
+pkg_postinst() {
+	if use bluetooth; then
+		elog "In order for bluetooth to function, you must start and add"
+		elog "bluetooth to your default runlevel:"
+		elog "  rc-service bluetooth start"
+		elog "  rc-update add bluetooth default"
+	fi
 }

--- a/cosmic-base/cosmic-settings/cosmic-settings-1.0.9.ebuild
+++ b/cosmic-base/cosmic-settings/cosmic-settings-1.0.9.ebuild
@@ -89,9 +89,13 @@ src_install() {
 
 pkg_postinst() {
 	if use bluetooth; then
-		elog "In order for bluetooth to function, you must start and add"
-		elog "bluetooth to your default runlevel:"
-		elog "  rc-service bluetooth start"
-		elog "  rc-update add bluetooth default"
+		elog "In order for bluetooth to function, you must start and enable"
+		elog "bluetooth:"
+		if use systemd; then
+			elog "  systemctl enable --now bluetooth"
+		else
+			elog "  rc-service bluetooth start"
+			elog "  rc-update add bluetooth default"
+		fi
 	fi
 }

--- a/cosmic-base/cosmic-settings/cosmic-settings-1.0.9.ebuild
+++ b/cosmic-base/cosmic-settings/cosmic-settings-1.0.9.ebuild
@@ -16,9 +16,10 @@ SRC_URI="https://github.com/fsvm88/cosmic-overlay/releases/download/${PV}/${PN}-
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE+=" +networkmanager openvpn"
+IUSE+=" +networkmanager openvpn bluetooth"
 
 RDEPEND+="
+	bluetooth? ( >=net-wireless/bluez-5.86 )
 	~cosmic-base/cosmic-icons-${PV}
 	~cosmic-base/cosmic-randr-${PV}
 	>=app-text/iso-codes-4.16.0
@@ -38,6 +39,34 @@ RDEPEND+="
 	>=x11-misc/xkeyboard-config-2.41
 "
 
+src_configure() {
+	local myfeatures=(
+		"a11y"
+		"cosmic-comp-config"
+		"page-accessibility"
+		"page-about"
+		$(usev bluetooth "page-bluetooth")
+		"page-date"
+		"page-default-apps"
+		"page-display"
+		"page-input"
+		"page-legacy-applications"
+		"page-networking"
+		"page-power"
+		"page-region"
+		"page-sound"
+		"page-users"
+		"page-window-management"
+		"page-workspaces"
+		"xdg-portal"
+		"wayland"
+		"single-instance"
+		"wgpu"
+	)
+
+	cosmic-de-r2_src_configure --no-default-features
+}
+
 src_install() {
 	dobin "$(cosmic-common_target_dir)/$PN"
 
@@ -56,4 +85,13 @@ src_install() {
 
 	insinto /usr/share/polkit-1/actions
 	doins resources/polkit-1/actions/com.system76.CosmicSettings.Users.policy
+}
+
+pkg_postinst() {
+	if use bluetooth; then
+		elog "In order for bluetooth to function, you must start and add"
+		elog "bluetooth to your default runlevel:"
+		elog "  rc-service bluetooth start"
+		elog "  rc-update add bluetooth default"
+	fi
 }

--- a/cosmic-base/cosmic-settings/cosmic-settings-9999.ebuild
+++ b/cosmic-base/cosmic-settings/cosmic-settings-9999.ebuild
@@ -17,9 +17,10 @@ EGIT_BRANCH=master
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS=""
-IUSE+=" +networkmanager openvpn"
+IUSE+=" +networkmanager openvpn bluetooth"
 
 RDEPEND+="
+	bluetooth? ( >=net-wireless/bluez-5.86 )
 	~cosmic-base/cosmic-icons-${PV}
 	~cosmic-base/cosmic-randr-${PV}
 	>=app-text/iso-codes-4.16.0
@@ -39,6 +40,34 @@ RDEPEND+="
 	>=x11-misc/xkeyboard-config-2.41
 "
 
+src_configure() {
+	local myfeatures=(
+		"a11y"
+		"cosmic-comp-config"
+		"page-accessibility"
+		"page-about"
+		$(usev bluetooth "page-bluetooth")
+		"page-date"
+		"page-default-apps"
+		"page-display"
+		"page-input"
+		"page-legacy-applications"
+		"page-networking"
+		"page-power"
+		"page-region"
+		"page-sound"
+		"page-users"
+		"page-window-management"
+		"page-workspaces"
+		"xdg-portal"
+		"wayland"
+		"single-instance"
+		"wgpu"
+	)
+
+	cosmic-de-r2_src_configure --no-default-features
+}
+
 src_install() {
 	dobin "$(cosmic-common_target_dir)/$PN"
 
@@ -57,4 +86,13 @@ src_install() {
 
 	insinto /usr/share/polkit-1/actions
 	doins resources/polkit-1/actions/com.system76.CosmicSettings.Users.policy
+}
+
+pkg_postinst() {
+	if use bluetooth; then
+		elog "In order for bluetooth to function, you must start and add"
+		elog "bluetooth to your default runlevel:"
+		elog "  rc-service bluetooth start"
+		elog "  rc-update add bluetooth default"
+	fi
 }

--- a/cosmic-base/cosmic-settings/cosmic-settings-9999.ebuild
+++ b/cosmic-base/cosmic-settings/cosmic-settings-9999.ebuild
@@ -90,9 +90,13 @@ src_install() {
 
 pkg_postinst() {
 	if use bluetooth; then
-		elog "In order for bluetooth to function, you must start and add"
-		elog "bluetooth to your default runlevel:"
-		elog "  rc-service bluetooth start"
-		elog "  rc-update add bluetooth default"
+		elog "In order for bluetooth to function, you must start and enable"
+		elog "bluetooth:"
+		if use systemd; then
+			elog "  systemctl enable --now bluetooth"
+		else
+			elog "  rc-service bluetooth start"
+			elog "  rc-update add bluetooth default"
+		fi
 	fi
 }


### PR DESCRIPTION
This PR provides the ability to conditionally compile bluetooth support into the settings application as well as adds the `net-wireless/bluez` dependency.

Fixes #149 