### PR TITLE
Add openrc settingsd dependency

### DIFF
--- a/cosmic-base/cosmic-initial-setup/cosmic-initial-setup-9999.ebuild
+++ b/cosmic-base/cosmic-initial-setup/cosmic-initial-setup-9999.ebuild
@@ -16,11 +16,13 @@ EGIT_BRANCH=master
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS=""
+IUSE+=" systemd"
 
 RDEPEND+="
 	acct-user/cosmic-initial-setup
 	~cosmic-base/pop-appstream-data-9999
 	~cosmic-base/cosmic-icons-${PV}
+	!systemd? ( >=app-admin/openrc-settingsd-1.4.0-r1 )
 "
 
 src_install() {

--- a/cosmic-base/cosmic-settings/cosmic-settings-9999.ebuild
+++ b/cosmic-base/cosmic-settings/cosmic-settings-9999.ebuild
@@ -66,7 +66,7 @@ src_configure() {
 		"wgpu"
 	)
 
-	cosmic-de-r2_src_configure --no-default-features
+	cosmic-live_src_configure --no-default-features
 }
 
 src_install() {


### PR DESCRIPTION
This adds openrc-settingsd as a runtime dependency for the cosmic-initial-setup application on systems that do not have the systemd use flag enabled. The work that I have done to cosmic-initial-setup to decouple it from systemd has been merged to trunk and should be available in the next COSMIC Epoch release. For now though, updating the live ebuild should be sufficient.

While testing the live ebuild, I also found and resolved an issue with a call to a non-existent function in the cosmic-settings live ebuild. It looks like we might have recently created a cosmic-live eclass and that call did not get updated.

Closes #142 