### PR TITLE
feat[cosmic-settings]: add support for OpenRC based service management

### DIFF
--- a/cosmic-base/cosmic-settings/cosmic-settings-9999.ebuild
+++ b/cosmic-base/cosmic-settings/cosmic-settings-9999.ebuild
@@ -48,7 +48,6 @@ src_configure() {
 		"page-accessibility"
 		"page-about"
 		$(usev bluetooth "page-bluetooth")
-		$(usex systemd "systemd" "openrc")
 		"page-date"
 		"page-default-apps"
 		"page-display"
@@ -61,6 +60,7 @@ src_configure() {
 		"page-users"
 		"page-window-management"
 		"page-workspaces"
+		$(usex systemd "systemd" "openrc")
 		"xdg-portal"
 		"wayland"
 		"single-instance"

--- a/cosmic-base/cosmic-settings/cosmic-settings-9999.ebuild
+++ b/cosmic-base/cosmic-settings/cosmic-settings-9999.ebuild
@@ -48,6 +48,7 @@ src_configure() {
 		"page-accessibility"
 		"page-about"
 		$(usev bluetooth "page-bluetooth")
+		$(usex systemd "systemd" "openrc")
 		"page-date"
 		"page-default-apps"
 		"page-display"


### PR DESCRIPTION
Integrates new `openrc` and `systemd` features for the COSMIC settings application. This was added to the COSMIC settings application in pop-os/cosmic-settings#1982.

Fixes #159