### PR TITLE
Integrate logind Flag Into cosmic-comp Live Ebuild

### DIFF
--- a/cosmic-base/cosmic-comp/cosmic-comp-9999.ebuild
+++ b/cosmic-base/cosmic-comp/cosmic-comp-9999.ebuild
@@ -26,11 +26,11 @@ RDEPEND+="
 "
 
 src_configure() {
-	if use elogind; then
-		cosmic-live_src_configure --no-default-features
-	else
-		cosmic-live_src_configure
-	fi
+	local myfeatures=(
+		$(usev elogind "logind")
+		$(usev systemd)
+	)
+	cosmic-live_src_configure --no-default-features
 }
 
 src_install() {


### PR DESCRIPTION
This enables the logind feature in cosmic-comp if the elogind USE flag is set and enables the systemd feature if the systemd USE flag is set. 

#165 