### PR TITLE
fix: remove outdated patch from live xdg-desktop-portal

### DIFF
--- a/cosmic-base/xdg-desktop-portal-cosmic/xdg-desktop-portal-cosmic-9999.ebuild
+++ b/cosmic-base/xdg-desktop-portal-cosmic/xdg-desktop-portal-cosmic-9999.ebuild
@@ -18,10 +18,6 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS=""
 
-PATCHES=(
-	"${FILESDIR}/xdg-desktop-portal-1.0.0_beta3-add-SystemdService-directive.patch"
-)
-
 RDEPEND+="
 	>=media-libs/mesa-24.0.4
 	>=media-video/pipewire-1.0.3


### PR DESCRIPTION
Fixed upstream in 1.4.0: https://github.com/pop-os/xdg-desktop-portal-cosmic/commit/9923d0b37636aac93c30af033208c139746acb66