### PR TITLE
fix: xdg-desktop-portal's service filename

### DIFF
--- a/cosmic-base/xdg-desktop-portal-cosmic/xdg-desktop-portal-cosmic-1.4.0.ebuild
+++ b/cosmic-base/xdg-desktop-portal-cosmic/xdg-desktop-portal-cosmic-1.4.0.ebuild
@@ -48,7 +48,7 @@ src_install() {
 	doexe "$(cosmic-common_target_dir)/$PN"
 
 	systemd_newuserunit data/org.freedesktop.impl.portal.desktop.cosmic.service.in \
-			xdg-desktop-portal-cosmic.service
+			org.freedesktop.impl.portal.desktop.cosmic.service
 
 	insinto /usr/share/dbus-1/services
 	newins data/dbus-1/org.freedesktop.impl.portal.desktop.cosmic.service.in \

--- a/cosmic-base/xdg-desktop-portal-cosmic/xdg-desktop-portal-cosmic-1.5.0.ebuild
+++ b/cosmic-base/xdg-desktop-portal-cosmic/xdg-desktop-portal-cosmic-1.5.0.ebuild
@@ -48,7 +48,7 @@ src_install() {
 	doexe "$(cosmic-common_target_dir)/$PN"
 
 	systemd_newuserunit data/org.freedesktop.impl.portal.desktop.cosmic.service.in \
-			xdg-desktop-portal-cosmic.service
+			org.freedesktop.impl.portal.desktop.cosmic.service
 
 	insinto /usr/share/dbus-1/services
 	newins data/dbus-1/org.freedesktop.impl.portal.desktop.cosmic.service.in \

--- a/cosmic-base/xdg-desktop-portal-cosmic/xdg-desktop-portal-cosmic-9999.ebuild
+++ b/cosmic-base/xdg-desktop-portal-cosmic/xdg-desktop-portal-cosmic-9999.ebuild
@@ -46,7 +46,7 @@ src_install() {
 	doexe "$(cosmic-common_target_dir)/$PN"
 
 	systemd_newuserunit data/org.freedesktop.impl.portal.desktop.cosmic.service.in \
-			xdg-desktop-portal-cosmic.service
+			org.freedesktop.impl.portal.desktop.cosmic.service
 
 	insinto /usr/share/dbus-1/services
 	newins data/dbus-1/org.freedesktop.impl.portal.desktop.cosmic.service.in \


### PR DESCRIPTION
When PR'ing https://github.com/fsvm88/cosmic-overlay/pull/177 I failed to notice that the line that was put in upstream for SystemdService was not the same. This caused the service to fail to start as the service file was incorrect from our side.

Our patch was `SystemdService=xdg-desktop-portal-cosmic.service`, the line upstream now is `SystemdService=org.freedesktop.impl.portal.desktop.cosmic.service`

This affected 1.4/1.5/live and caused services called through xdg not to work(like screenshots).

