### PR TITLE
[cosmic-base/cosmic-greeter] Add OpenRC init script for the greeter daemon

### DIFF
--- a/cosmic-base/cosmic-greeter/cosmic-greeter-1.7.0-r1.ebuild
+++ b/cosmic-base/cosmic-greeter/cosmic-greeter-1.7.0-r1.ebuild
@@ -3,32 +3,35 @@
 
 EAPI=8
 
-EGIT_LFS=1
 RUST_NEEDS_LLVM=1
 
-inherit cosmic-live pam systemd tmpfiles
+inherit cosmic-de-r2 pam systemd tmpfiles
 
 DESCRIPTION="libcosmic greeter for greetd from COSMIC DE"
 HOMEPAGE="https://github.com/pop-os/cosmic-greeter"
 
-EGIT_REPO_URI="${HOMEPAGE}"
-EGIT_BRANCH=master
+SRC_URI="https://github.com/fsvm88/cosmic-overlay/releases/download/${PV}/${PN}-${PV}.full.tar.zst"
 
 # use cargo-license for a more accurate license picture
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS=""
+KEYWORDS="~amd64"
 
 RDEPEND+="
 	~cosmic-base/cosmic-comp-${PV}
 	>=acct-user/cosmic-greeter-0
 	>=dev-libs/libinput-1.26.1
 	>=gui-libs/greetd-0.9.0
+	>=media-libs/dav1d-1.4.2
 	>=sys-libs/pam-1.5.3-r1
 "
 
 src_configure() {
-	cosmic-live_src_configure --all
+	# Required for some crates to build properly due to build.rs scripts
+	export VERGEN_GIT_COMMIT_DATE='Tue Aug 25 02:33:15 2026 +0200'
+	export VERGEN_GIT_SHA=935891e36bf265a3c65906694badc1e66cfc091d
+
+	cosmic-de-r2_src_configure --all
 }
 
 src_install() {
@@ -53,7 +56,7 @@ src_install() {
 		-e '/#\[Install\]/s/^#//' \
 		-e '/#Alias/s/^#//' \
 		debian/cosmic-greeter.service
-	systemd_dounit debian/cosmic-greeter.service
+	systemd_dounit debian/cosmic-greeter.service || die "failed to patch systemd unit via sed"
 
 	newtmpfiles "${FILESDIR}/systemd.tmpfiles" "${PN}.conf"
 }

--- a/cosmic-base/cosmic-greeter/files/cosmic-greeter-daemon.init
+++ b/cosmic-base/cosmic-greeter/files/cosmic-greeter-daemon.init
@@ -1,0 +1,16 @@
+#!/sbin/openrc-run
+# Copyright 2026 Erik Dannenberg
+# Distributed under the terms of the GNU General Public License v2
+
+description="COSMIC greeter daemon, provides per-user config data to the greeter"
+
+command="/usr/bin/cosmic-greeter-daemon"
+command_background="true"
+pidfile="${pidfile:-/run/${RC_SVCNAME}.pid}"
+LOGFILE="/var/log/${RC_SVCNAME}.log"
+start_stop_daemon_args="--stderr ${LOGFILE} --stdout ${LOGFILE}"
+
+depend() {
+	need dbus
+	before display-manager
+}


### PR DESCRIPTION
cosmic-greeter-daemon was only installed with a systemd unit. On OpenRC the daemon never runs, so the greeter cannot fetch per-user data over D-Bus and falls back to the default background and theme instead of the selected user's wallpaper.
