### PR TITLE
[cosmic-base/cosmic-applets] Add missing upower dependency #184

### DIFF
--- a/cosmic-base/cosmic-applets/cosmic-applets-1.7.0-r1.ebuild
+++ b/cosmic-base/cosmic-applets/cosmic-applets-1.7.0-r1.ebuild
@@ -14,9 +14,11 @@ SRC_URI="https://github.com/fsvm88/cosmic-overlay/releases/download/${PV}/${PN}-
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64"
+IUSE="+upower"
 
 RDEPEND+="
 ~cosmic-base/cosmic-icons-${PV}
+upower? ( >=sys-power/upower-1.90.0 )
 "
 
 _install_icons() {

--- a/cosmic-base/cosmic-applets/cosmic-applets-9999.ebuild
+++ b/cosmic-base/cosmic-applets/cosmic-applets-9999.ebuild
@@ -16,8 +16,11 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS=""
 
+IUSE="+upower"
+
 RDEPEND+="
 ~cosmic-base/cosmic-icons-${PV}
+upower? ( >=sys-power/upower-1.90.0 )
 "
 
 _install_icons() {

--- a/cosmic-base/system76-power/system76-power-9999.ebuild
+++ b/cosmic-base/system76-power/system76-power-9999.ebuild
@@ -50,3 +50,12 @@ src_install() {
 	newinitd "${FILESDIR}"/${PN}.init ${PN}
 	systemd_dounit "data/${appid}.service"
 }
+
+pkg_postinst() {
+	if [[ ! -d /run/systemd/system ]]; then
+		elog "On OpenRC the power daemon must be enabled manually:"
+		elog "    rc-update add ${PN} default"
+		elog "    rc-service ${PN} start"
+		elog "COSMIC power profile switching requires the running daemon."
+	fi
+}


### PR DESCRIPTION
The battery applet reads charge state from upowerd via D-Bus, but
nothing in the COSMIC dependency tree pulls in upower, so on a fresh
install the applet permanently shows 0% until sys-power/upower is
installed by hand.

Also added a postinst message to enable system76-power on OpenRC.